### PR TITLE
update Dockerfile and add CI workflow with build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: Mynd CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
+env:
+  CI_PROJECT_DIR: ${{ github.workspace }}
+
+jobs:
+  build:
+    name: build_${{ matrix.project }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jomosa24/myndfirmware:latest
+      options: --platform linux/amd64
+      credentials:
+        username: ${{ secrets.GHCR_USER }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: Mynd
+            buildTargets: "mynd-update-firmware-mcu mynd-factory-update-firmware-mcu"
+          - project: MyndBootloader
+            buildTargets: "mynd-bootloader"
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build artifacts
+        env:
+          TFL_PROJECT_NAME: ${{ matrix.project }}
+          TFL_BUILD_TARGETS: ${{ matrix.buildTargets }}
+          TFL_CMAKE_TOOLCHAIN_PREFIX: /usr/local
+          TFL_CMAKE_BUILD_TYPE: Release
+          TFL_PROJECT_DIR: ${{ env.CI_PROJECT_DIR }}
+        run: ${CI_PROJECT_DIR}/support/scripts/cicd/shell/build_artifacts.sh
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_${{ matrix.project }}
+          path: ${{ env.CI_PROJECT_DIR }}/build/Projects/${{ matrix.project }}
+          if-no-files-found: error
+      - name: Upload CMake logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmake-logs_${{ matrix.project }}
+          path: |
+            ${{ env.CI_PROJECT_DIR }}/build/CMakeFiles/CMakeOutput.log
+            ${{ env.CI_PROJECT_DIR }}/build/CMakeFiles/CMakeError.log
+          if-no-files-found: ignore
+          retention-days: 1

--- a/support/docker-build/docker-config/Dockerfile
+++ b/support/docker-build/docker-config/Dockerfile
@@ -1,15 +1,10 @@
-FROM frolvlad/alpine-glibc:glibc-2.28
+FROM alpine:3.20
 
-RUN apk --update --no-cache upgrade && \
-    apk --update --no-cache add make cmake python2 python3 py-pip protobuf git git-lfs ninja openssl && \
-    apk --update --no-cache add --virtual build-dependencies w3m wget curl ca-certificates && \
+RUN apk --update --no-cache add make cmake git git-lfs ninja openssl protobuf libc6-compat libstdc++ ca-certificates && \
+    apk --update --no-cache add --virtual build-dependencies w3m wget curl bzip2 && \
     wget --no-check-certificate -O /tmp/gcc-arm-none-eabi.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.bz2 && \
     tar xf /tmp/gcc-arm-none-eabi.tar.bz2 --strip-components=1 -C /usr/local && \
     rm -rf /tmp/gcc-arm-none-eabi.tar.bz2 && \
     rm -rf /usr/local/share/doc && \
-    curl -fL https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.49.1/scripts/install-cli.sh | sh && \
     apk del build-dependencies
-RUN pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install --no-cache-dir protobuf && \
-    pip3 install --no-cache-dir crcmod && \
-    pip3 install --no-cache-dir intelhex
+RUN apk add --no-cache python3 py3-pip py3-protobuf py3-crcmod py3-intelhex

--- a/support/scripts/cicd/shell/build_artifacts.sh
+++ b/support/scripts/cicd/shell/build_artifacts.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -ex
+
+### MAIN ###
+
+mkdir -p "${TFL_PROJECT_DIR}/build"
+cd "${TFL_PROJECT_DIR}/build"
+
+cmake \
+  -DPROJECT="${TFL_PROJECT_NAME}" \
+  -DTOOLCHAIN_PREFIX="${TFL_CMAKE_TOOLCHAIN_PREFIX}" \
+  -DCMAKE_BUILD_TYPE="${TFL_CMAKE_BUILD_TYPE}" \
+  .. -G Ninja
+
+ninja $TFL_BUILD_TARGETS # Allow word expansion for multiple targets, do not quote this variable
+
+ls -lsa "${TFL_PROJECT_DIR}/build/Projects/${TFL_PROJECT_NAME}"


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to streamline the building of firmware for Mynd projects. 

Key Changes:

GitHub Actions Workflow (.github/workflows/ci.yml):
 - Utilizes matrix strategy supporting Mynd and MyndBootloader projects with corresponding build targets.
 - Implements artifact upload for build outputs and CMake logs on failure for better diagnostics.
 
Dockerfile Updates (support/docker-build/docker-config/Dockerfile):
 - Replaced base image from frolvlad/alpine-glibc:glibc-2.28 to alpine:3.20 for updated base system.
 - Optimized package installations:
     - Reduced redundant packages.
     - Consolidated Python dependencies using py3-* packages for better compatibility.
     - Improved ARM toolchain installation process.
 
New Build Script (support/scripts/cicd/shell/build_artifacts.sh):
 - Automates CMake configuration and triggering of Ninja builds.
 - Supports dynamic project and build target configurations via environment variables.
 - Lists build artifacts to verify successful builds.